### PR TITLE
Fix duplicate taxonomy key in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -777,7 +777,7 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
   page = ["HTML", "MarkDown"]
   section = ["HTML", "RSS"]
   taxonomy = ["HTML", "RSS"]
-  taxonomyTerm = ["HTML"]
+  term = ["HTML"]
 
 # Multilingual
 # 多语言


### PR DESCRIPTION
- Changed taxonomyTerm to term in outputs configuration
- Resolves ''toml: key taxonomy is already defined'' error